### PR TITLE
Adapt existing reputer to support multiple tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,9 @@ import json
 import random
 
 
-ETHUSD_TOKEN = "ETHUSD"
+TOKEN = os.environ['TOKEN']
+TOKEN_CG_ID = os.environ['TOKEN_CG_ID']
+
 API_PORT = int(os.environ.get('API_PORT', 5000))
 ALLORA_VALIDATOR_API_URL = str(os.environ.get('ALLORA_VALIDATOR_API_URL','http://localhost:1317/emissions/v1/network_loss/'))
 app = Flask(__name__)
@@ -17,11 +19,12 @@ DATABASE_PATH = os.environ.get('DATABASE_PATH', 'prices.db')
 GEN_TEST_DATA = bool(os.environ.get('GEN_TEST_DATA', False))
 WORKER_ADDRESS_TEST_1 = str(os.environ.get('WORKER_ADDRESS_TEST_1', "allo1tvh6nv02vq6m4mevsa9wkscw53yxvfn7xt8rud"))
 
+TOKEN_NAME = f"{TOKEN}USD"
+
 HTTP_RESPONSE_CODE_200 = 200
 HTTP_RESPONSE_CODE_400 = 400
 HTTP_RESPONSE_CODE_404 = 404
 HTTP_RESPONSE_CODE_500 = 500
-
 
 # Define retry decorator
 @retrying.retry(wait_exponential_multiplier=1000, wait_exponential_max=10000, stop_max_attempt_number=5)
@@ -184,6 +187,6 @@ def get_losses(topic, blockHeight):
             return '{}', HTTP_RESPONSE_CODE_500
 
 if __name__ == '__main__':
-    init_price_token(ETHUSD_TOKEN, 'ethereum', 'usd')
+    init_price_token(TOKEN_NAME, TOKEN_CG_ID, 'usd')
     app.run(host='0.0.0.0', port=API_PORT)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - API_PORT=8000
       # - ALLORA_VALIDATOR_API_URL=https://allora-api.testnet.allora.network/emissions/v1/network_loss/
       - ALLORA_VALIDATOR_API_URL=https://localhost:1317/emissions/v1/network_loss/
+      - TOKEN=BTC
+      - TOKEN_CG_ID=bitcoin
     # For local testing via URL without workers/heads up:
     ports:
       - "8000:8000"
@@ -27,6 +29,7 @@ services:
       - DATA_PROVIDER_API_ADDRESS=http://data-provider:8000
       - HOME=/data
       - LOG_FILE=/tmp/app.log
+      - TOKEN=BTC
     build:
       context: .
       dockerfile: Dockerfile_b7s

--- a/main.py
+++ b/main.py
@@ -14,7 +14,9 @@ def config_logging(log_file):
     # Configure logging to only log to file
     logging.basicConfig(filename=log_file, level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-ETHUSD_TOKEN = "ETHUSD"
+TOKEN = os.environ.get('TOKEN', "ETH")
+TOKEN_NAME = f"{TOKEN}USD"
+
 DATA_PROVIDER_API_ADDRESS = os.environ['DATA_PROVIDER_API_ADDRESS']
 LOG_FILE = os.environ.get('LOG_FILE', '/tmp/app.log')
 config_logging(LOG_FILE)
@@ -43,7 +45,7 @@ if __name__ == "__main__":
             blockHeightEval = sys.argv[3]
             timestamp = sys.argv[4]  # timestamp of the block
         logging.info(f"Arguments: {topic_id}, {blockHeight}, {blockHeightEval}, {timestamp}")
-        response_gt = get_ground_truth(token_name=ETHUSD_TOKEN, timestamp=timestamp)
+        response_gt = get_ground_truth(token_name=TOKEN_NAME, timestamp=timestamp)
         json_gt = json.loads(response_gt)
         try:
             response_losses = get_previous_losses(topic_id, blockHeightEval)


### PR DESCRIPTION
Adding the following env variables for supporting multiple tokens:

- Data provider:
  - TOKEN - Symbol of the token the ground truth is provided for
  - TOKEN_CG_ID - Coingecko id of the token the ground truth is provided for. 
  Note: initially tried to get the token's Coingecko id using the token symbol to search in the list provided [here](https://api.coingecko.com/api/v3/coins/list). However, the same symbol could match multiple Coingecko ids (eg: "btc").
  
 - Reputer b7 node:
   - TOKEN - Symbol of the token the ground truth is requested for